### PR TITLE
Fix blog post formatting errors

### DIFF
--- a/_posts/2024-02-02-rl-deepmind-x-ucl-4-theoretical-fundamentals-of-dynam.md
+++ b/_posts/2024-02-02-rl-deepmind-x-ucl-4-theoretical-fundamentals-of-dynam.md
@@ -8,20 +8,18 @@ categories: education
 lang: en
 ---
 
-
 ## The Banach Fixed Point Theorem
 
 Let $X$ be a complete normed vector space, equipped with a norm $\|\cdot\|$ and $T:X \rightarrow X$ a $\gamma$-contraction mapping, then:
 
 1. $T$ has a unique fixed point $x^* \in X$ s.t. $T x^*=x^*$
 2. $\forall x_0 \in X$, the sequence $x_{n+1}=Tx_n$ converges to $x^*$ in a geometric fashion:
-    
-    $$
-    \|x_n-x^*\| \le \gamma^n\|x_0-x^*\|
-    $$
-    
-    Thus, $\lim_{n\rightarrow\infty}\|x_n-x^*\|\le \lim_{n\rightarrow\infty}\gamma^n\|x_0-x^*\|=0.$
-    
+
+   $$
+   \|x_n-x^*\| \le \gamma^n\|x_0-x^*\|
+   $$
+
+   Thus, $\lim_{n\rightarrow\infty}\|x_n-x^*\|\le \lim_{n\rightarrow\infty}\gamma^n\|x_0-x^*\|=0.$
 
 ## What does this mean?
 
@@ -107,11 +105,11 @@ This is the q-version of the previous Bellman Expectation Operator $T_V^\pi$. It
 
 1. $T^*$ has a unique fixed point $v^*$.
 2. $T^*$ is a $\gamma$-contraction with respect to $\|\cdot\|_\infty$:
-    
-    $$
-    \|T^*v-T^*u\|_\infty \le \gamma \|v-u\|_\infty, \forall u,v \in V
-    $$
-    
+
+   $$
+   \|T^*v-T^*u\|_\infty \le \gamma \|v-u\|_\infty, \forall u,v \in V
+   $$
+
 3. $T^*$ is monotonic:
 
 $$

--- a/_posts/2024-02-02-rl-deepmind-x-ucl-4-theoretical-fundamentals-of-dynam.md
+++ b/_posts/2024-02-02-rl-deepmind-x-ucl-4-theoretical-fundamentals-of-dynam.md
@@ -99,7 +99,7 @@ $$
 
 ### What is this operator?
 
-This is the q-version of the previous Bellman Expectation Operator $T_V^\pi$. It is also a $\gamma$-contraction, with the unique fixed point being $f=q^\pi$. Therefore, we can evaluate the policy $\pi$ by repeatedly applying this operator to the initial value function $q$. We then know the performance of the policy $\pi$. Since this is a q-value function, we can also use it to greedify our policy $\pi$ by $\pi \leftarrow \argmax_{a\in A} q^\pi(s, a)$.
+This is the q-version of the previous Bellman Expectation Operator $T_V^\pi$. It is also a $\gamma$-contraction, with the unique fixed point being $f=q^\pi$. Therefore, we can evaluate the policy $\pi$ by repeatedly applying this operator to the initial value function $q$. We then know the performance of the policy $\pi$. Since this is a q-value function, we can also use it to greedify our policy $\pi$ by $\pi \leftarrow \operatorname{argmax}_{a\in A} q^\pi(s, a)$.
 
 ## Properties of the Bellman Operators
 

--- a/_posts/2024-02-04-rl-deepmind-x-ucl-6-model-free-control-c55a856c97414c.md
+++ b/_posts/2024-02-04-rl-deepmind-x-ucl-6-model-free-control-c55a856c97414c.md
@@ -8,17 +8,16 @@ categories: education
 lang: en
 ---
 
-
 ## GLIE
 
 GLIE stands for **Greedy in the Limit with Infinite Exploration**. It is used to describe a set of desirable properties of a policy. GLIE is a combination of the following two properties:
 
 1. **Greedy in the Limit** means that the policy eventually converges to a greedy policy, i.e.
-    
-    $$
-    \lim_{t \rightarrow \infty} {\pi_t(a|s)}=I(a=\operatorname{argmax}_{a' \in A}{q_t(s,a')})
-    $$
-    
+
+   $$
+   \lim_{t \rightarrow \infty} {\pi_t(a|s)}=I(a=\operatorname{argmax}_{a' \in A}{q_t(s,a')})
+   $$
+
 2. **Infinite Exploration** means that all state-action pairs are explored infinitely many times, i.e.
 
 $$
@@ -93,7 +92,7 @@ $$
 \max_{a' \in A}{q_t(S_{t+1}, a')}=q_t\left(S_{t+1}, \operatorname{argmax}_{a' \in A} q_t(S_{t+1}, a')\right)
 $$
 
-Suppose that the value function is currently inaccurate and has high noise. For simplicity, assume that the optimal q-value function $q^*(S_{t+1},a')$ stays constant regardless of the action $a'$ taken. For some of the $a'$s, the noise will add up to increase $q$. Therefore, the $\operatorname{argmax}_{a' \in A}$ will choose the $a'$ with the highest noise value then update $q(S_t, A_t)$ towards the noise-added value. Similar logic applies to the case where  $q^*(S_{t+1},a')$ is not constant with respect to $a'$. Hence, Q-learning tends to overestimate the optimal $q$-value function.
+Suppose that the value function is currently inaccurate and has high noise. For simplicity, assume that the optimal q-value function $q^*(S_{t+1},a')$ stays constant regardless of the action $a'$ taken. For some of the $a'$s, the noise will add up to increase $q$. Therefore, the $\operatorname{argmax}_{a' \in A}$ will choose the $a'$ with the highest noise value then update $q(S_t, A_t)$ towards the noise-added value. Similar logic applies to the case where $q^*(S_{t+1},a')$ is not constant with respect to $a'$. Hence, Q-learning tends to overestimate the optimal $q$-value function.
 
 ### Double Q-Learning
 
@@ -108,7 +107,7 @@ This eliminates the influence of noise by decoupling the selection ($\operatorna
 ![Q-learning overestimates, whereas double Q-learning does not. 
 (Source: DeepMind X UCL Deep RL lectures)](/assets/img/blog/reinforcement-learning/screenshot_2023-08-30_at_3.44.02_pm.png)
 
-Q-learning overestimates, whereas double Q-learning does not. 
+Q-learning overestimates, whereas double Q-learning does not.
 (Source: DeepMind X UCL Deep RL lectures)
 
 The above plot shows how decoupling indeed eliminates the overestimation in Q-learning. We can also apply this method to SARSA whenever the behavior policy is (soft) greedy and has correlation with $q$ (we call this double SARSA).

--- a/_posts/2024-02-04-rl-deepmind-x-ucl-6-model-free-control-c55a856c97414c.md
+++ b/_posts/2024-02-04-rl-deepmind-x-ucl-6-model-free-control-c55a856c97414c.md
@@ -16,7 +16,7 @@ GLIE stands for **Greedy in the Limit with Infinite Exploration**. It is used to
 1. **Greedy in the Limit** means that the policy eventually converges to a greedy policy, i.e.
     
     $$
-    \lim_{t \rightarrow \infty} {\pi_t(a|s)}=I(a=\argmax_{a' \in A}{q_t(s,a')})
+    \lim_{t \rightarrow \infty} {\pi_t(a|s)}=I(a=\operatorname{argmax}_{a' \in A}{q_t(s,a')})
     $$
     
 2. **Infinite Exploration** means that all state-action pairs are explored infinitely many times, i.e.
@@ -69,7 +69,7 @@ $$
 Here, there is no policy $\pi$ involved - you can use any behavior policy $\mu$ to converge to the optimal value function $q^*$, as long as it is a infinite exploration policy. Once $q^*$ is learned, we can use the (optimal) greedy policy for exploitation:
 
 $$
-{\pi^*(a|s)}=I(a=\argmax_{a'\in A}{q^*(s,a')}).
+{\pi^*(a|s)}=I(a=\operatorname{argmax}_{a'\in A}{q^*(s,a')}).
 $$
 
 ### Theorem
@@ -90,20 +90,20 @@ $$
 To write things differently:
 
 $$
-\max_{a' \in A}{q_t(S_{t+1}, a')}=q_t\left(S_{t+1}, \argmax_{a' \in A} q_t(S_{t+1}, a')\right)
+\max_{a' \in A}{q_t(S_{t+1}, a')}=q_t\left(S_{t+1}, \operatorname{argmax}_{a' \in A} q_t(S_{t+1}, a')\right)
 $$
 
-Suppose that the value function is currently inaccurate and has high noise. For simplicity, assume that the optimal q-value function $q^*(S_{t+1},a')$ stays constant regardless of the action $a'$ taken. For some of the $a'$s, the noise will add up to increase $q$. Therefore, the $\argmax_{a' \in A}$ will choose the $a'$ with the highest noise value then update $q(S_t, A_t)$ towards the noise-added value. Similar logic applies to the case where  $q^*(S_{t+1},a')$ is not constant with respect to $a'$. Hence, Q-learning tends to overestimate the optimal $q$-value function.
+Suppose that the value function is currently inaccurate and has high noise. For simplicity, assume that the optimal q-value function $q^*(S_{t+1},a')$ stays constant regardless of the action $a'$ taken. For some of the $a'$s, the noise will add up to increase $q$. Therefore, the $\operatorname{argmax}_{a' \in A}$ will choose the $a'$ with the highest noise value then update $q(S_t, A_t)$ towards the noise-added value. Similar logic applies to the case where  $q^*(S_{t+1},a')$ is not constant with respect to $a'$. Hence, Q-learning tends to overestimate the optimal $q$-value function.
 
 ### Double Q-Learning
 
 How can we solve this problem? We can store two action value functions, $q$ and $q'$, and alternate between the two targets below:
 
 $$
-\text{(target for }q \text{):}\;\;R_{t+1} + \gamma q'\left(S_{t+1}, \argmax_{a' \in A} q(S_{t+1},a')\right) \\ \text{(target for }q' \text{):}\;\;R_{t+1} + \gamma q\left(S_{t+1}, \argmax_{a' \in A} q'(S_{t+1},a')\right)
+\text{(target for }q \text{):}\;\;R_{t+1} + \gamma q'\left(S_{t+1}, \operatorname{argmax}_{a' \in A} q(S_{t+1},a')\right) \\ \text{(target for }q' \text{):}\;\;R_{t+1} + \gamma q\left(S_{t+1}, \operatorname{argmax}_{a' \in A} q'(S_{t+1},a')\right)
 $$
 
-This eliminates the influence of noise by decoupling the selection ($\argmax$) step and the evaluation step.
+This eliminates the influence of noise by decoupling the selection ($\operatorname{argmax}$) step and the evaluation step.
 
 ![Q-learning overestimates, whereas double Q-learning does not. 
 (Source: DeepMind X UCL Deep RL lectures)](/assets/img/blog/reinforcement-learning/screenshot_2023-08-30_at_3.44.02_pm.png)

--- a/assets/blog/reinforcement-learning-basics/DeepMind X UCL 4 Theoretical Fundamentals of Dynam 7478da99308c409ebe009bf4f8209c13.md
+++ b/assets/blog/reinforcement-learning-basics/DeepMind X UCL 4 Theoretical Fundamentals of Dynam 7478da99308c409ebe009bf4f8209c13.md
@@ -90,7 +90,7 @@ $$
 
 ### What is this operator?
 
-This is the q-version of the previous Bellman Expectation Operator $T_V^\pi$. It is also a $\gamma$-contraction, with the unique fixed point being $f=q^\pi$. Therefore, we can evaluate the policy $\pi$ by repeatedly applying this operator to the initial value function $q$. We then know the performance of the policy $\pi$. Since this is a q-value function, we can also use it to greedify our policy $\pi$ by $\pi \leftarrow \argmax_{a\in A} q^\pi(s, a)$.
+This is the q-version of the previous Bellman Expectation Operator $T_V^\pi$. It is also a $\gamma$-contraction, with the unique fixed point being $f=q^\pi$. Therefore, we can evaluate the policy $\pi$ by repeatedly applying this operator to the initial value function $q$. We then know the performance of the policy $\pi$. Since this is a q-value function, we can also use it to greedify our policy $\pi$ by $\pi \leftarrow \operatorname{argmax}_{a\in A} q^\pi(s, a)$.
 
 ## Properties of the Bellman Operators
 

--- a/assets/blog/reinforcement-learning-basics/DeepMind X UCL 6 Model-free Control c55a856c97414c309f4e93dff6774282.md
+++ b/assets/blog/reinforcement-learning-basics/DeepMind X UCL 6 Model-free Control c55a856c97414c309f4e93dff6774282.md
@@ -7,7 +7,7 @@ GLIE stands for **Greedy in the Limit with Infinite Exploration**. It is used to
 1. **Greedy in the Limit** means that the policy eventually converges to a greedy policy, i.e.
     
     $$
-    \lim_{t \rightarrow \infty} {\pi_t(a|s)}=I(a=\argmax_{a' \in A}{q_t(s,a')})
+    \lim_{t \rightarrow \infty} {\pi_t(a|s)}=I(a=\operatorname{argmax}_{a' \in A}{q_t(s,a')})
     $$
     
 2. **Infinite Exploration** means that all state-action pairs are explored infinitely many times, i.e.
@@ -60,7 +60,7 @@ $$
 Here, there is no policy $\pi$ involved - you can use any behavior policy $\mu$ to converge to the optimal value function $q^*$, as long as it is a infinite exploration policy. Once $q^*$ is learned, we can use the (optimal) greedy policy for exploitation:
 
 $$
-{\pi^*(a|s)}=I(a=\argmax_{a'\in A}{q^*(s,a')}).
+{\pi^*(a|s)}=I(a=\operatorname{argmax}_{a'\in A}{q^*(s,a')}).
 $$
 
 ### Theorem
@@ -81,20 +81,20 @@ $$
 To write things differently:
 
 $$
-\max_{a' \in A}{q_t(S_{t+1}, a')}=q_t\left(S_{t+1}, \argmax_{a' \in A} q_t(S_{t+1}, a')\right)
+\max_{a' \in A}{q_t(S_{t+1}, a')}=q_t\left(S_{t+1}, \operatorname{argmax}_{a' \in A} q_t(S_{t+1}, a')\right)
 $$
 
-Suppose that the value function is currently inaccurate and has high noise. For simplicity, assume that the optimal q-value function $q^*(S_{t+1},a')$ stays constant regardless of the action $a'$ taken. For some of the $a'$s, the noise will add up to increase $q$. Therefore, the $\argmax_{a' \in A}$ will choose the $a'$ with the highest noise value then update $q(S_t, A_t)$ towards the noise-added value. Similar logic applies to the case where  $q^*(S_{t+1},a')$ is not constant with respect to $a'$. Hence, Q-learning tends to overestimate the optimal $q$-value function.
+Suppose that the value function is currently inaccurate and has high noise. For simplicity, assume that the optimal q-value function $q^*(S_{t+1},a')$ stays constant regardless of the action $a'$ taken. For some of the $a'$s, the noise will add up to increase $q$. Therefore, the $\operatorname{argmax}_{a' \in A}$ will choose the $a'$ with the highest noise value then update $q(S_t, A_t)$ towards the noise-added value. Similar logic applies to the case where  $q^*(S_{t+1},a')$ is not constant with respect to $a'$. Hence, Q-learning tends to overestimate the optimal $q$-value function.
 
 ### Double Q-Learning
 
 How can we solve this problem? We can store two action value functions, $q$ and $q'$, and alternate between the two targets below:
 
 $$
-\text{(target for }q \text{):}\;\;R_{t+1} + \gamma q'\left(S_{t+1}, \argmax_{a' \in A} q(S_{t+1},a')\right) \\ \text{(target for }q' \text{):}\;\;R_{t+1} + \gamma q\left(S_{t+1}, \argmax_{a' \in A} q'(S_{t+1},a')\right)
+\text{(target for }q \text{):}\;\;R_{t+1} + \gamma q'\left(S_{t+1}, \operatorname{argmax}_{a' \in A} q(S_{t+1},a')\right) \\ \text{(target for }q' \text{):}\;\;R_{t+1} + \gamma q\left(S_{t+1}, \operatorname{argmax}_{a' \in A} q'(S_{t+1},a')\right)
 $$
 
-This eliminates the influence of noise by decoupling the selection ($\argmax$) step and the evaluation step.
+This eliminates the influence of noise by decoupling the selection ($\operatorname{argmax}$) step and the evaluation step.
 
 ![Q-learning overestimates, whereas double Q-learning does not. 
 (Source: DeepMind X UCL Deep RL lectures)](DeepMind%20X%20UCL%206%20Model-free%20Control%20c55a856c97414c309f4e93dff6774282/Screenshot_2023-08-30_at_3.44.02_PM.png)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "al-folio",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Replace `\argmax` with `\operatorname{argmax}` for correct LaTeX rendering of the argmax operator.

---
<a href="https://cursor.com/background-agent?bcId=bc-614cfd0d-f0be-4f5c-af4f-f3d496339e2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-614cfd0d-f0be-4f5c-af4f-f3d496339e2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

