### PR TITLE
Fix and generalize formatting errors in blog

### DIFF
--- a/assets/blog/reinforcement-learning-basics/DeepMind X UCL 4 Theoretical Fundamentals of Dynam 7478da99308c409ebe009bf4f8209c13.md
+++ b/assets/blog/reinforcement-learning-basics/DeepMind X UCL 4 Theoretical Fundamentals of Dynam 7478da99308c409ebe009bf4f8209c13.md
@@ -4,14 +4,14 @@
 
 Let $X$ be a complete normed vector space, equipped with a norm $\|\cdot\|$ and $T:X \rightarrow X$ a $\gamma$-contraction mapping, then:
 
-1. $T$ has a unique fixed point $x^* \in X$ s.t. $T x^*=x^*$
-2. $\forall x_0 \in X$, the sequence $x_{n+1}=Tx_n$ converges to $x^*$ in a geometric fashion:
+1. $T$ has a unique fixed point $x^\ast \in X$ s.t. $T x^\ast=x^\ast$
+2. $\forall x_0 \in X$, the sequence $x_{n+1}=Tx_n$ converges to $x^\ast$ in a geometric fashion:
     
     $$
-    \|x_n-x^*\| \le \gamma^n\|x_0-x^*\|
+    \|x_n-x^\ast\| \le \gamma^n\|x_0-x^\ast\|
     $$
     
-    Thus, $\lim_{n\rightarrow\infty}\|x_n-x^*\|\le \lim_{n\rightarrow\infty}\gamma^n\|x_0-x^*\|=0.$
+    Thus, $\lim_{n\rightarrow\infty}\|x_n-x^\ast\|\le \lim_{n\rightarrow\infty}\gamma^n\|x_0-x^\ast\|=0.$
     
 
 ## What does this mean?
@@ -20,19 +20,19 @@ It means that if the distance between two points after applying some operator $T
 
 ## Definitions of the Bellman Operators
 
-### Definition: Bellman Optimality Operator $T_V^*$
+### Definition: Bellman Optimality Operator $T_V^\ast$
 
-Given an MDP, $M=\langle S, A, p, r, \gamma \rangle$, let $V=V_S$ be the space of bounded real-valued functions over $S$. We define, point-wise, the Bellman Optimality Operator $T_V^*:V\rightarrow V$ as:
+Given an MDP, $M=\langle S, A, p, r, \gamma \rangle$, let $V=V_S$ be the space of bounded real-valued functions over $S$. We define, point-wise, the Bellman Optimality Operator $T_V^\ast:V\rightarrow V$ as:
 
 $$
 (T_V^*f)(s)=\max_{a \in A} \biggl[ {r(s, a) + \gamma \mathbb{E} \left[f(s')|s, a\right]} \bigg], \;\forall f \in V
 $$
 
-Sometimes we drop the index and use $T^*=T_V^*$.
+Sometimes we drop the index and use $T^\ast=T_V^\ast$.
 
 ### What is this operator?
 
-This operator is a $\gamma$-contraction with the unique fixed point being $f=v^*$, the optimal value function of the MDP. Therefore, if we apply this operator iteratively to some (value) function $v$, it will converge to the optimal value function $v^*$. This is why we attempt to approximate this specific operator (possibly with a neural network).
+This operator is a $\gamma$-contraction with the unique fixed point being $f=v^\ast$, the optimal value function of the MDP. Therefore, if we apply this operator iteratively to some (value) function $v$, it will converge to the optimal value function $v^\ast$. This is why we attempt to approximate this specific operator (possibly with a neural network).
 
 ### Definition: Bellman Expectation Operator $T^\pi_V$
 
@@ -56,9 +56,9 @@ Sometimes we drop the index and use $T^\pi=T_V^\pi$.
 
 Same as the Bellman Optimality Operator, this operator is a $\gamma$-contraction except the unique fixed point being $f=v^\pi$, the value function for policy $\pi$ in a given MDP. Therefore, we can evaluate the policy $\pi$ by repeatedly applying this operator to the initial (value) function $v$. We then know whether the policy $\pi$ is doing well or not.
 
-### Definition: Bellman Optimality Operator $T_Q^*$
+### Definition: Bellman Optimality Operator $T_Q^\ast$
 
-Given an MDP, $M=\langle S, A, p, r, \gamma \rangle$, let $Q=Q_{S, A}$ be the space of bounded real-valued functions over $S\times A$. We define the Bellman Optimality Operator $T_Q^*:Q\rightarrow Q$ as:
+Given an MDP, $M=\langle S, A, p, r, \gamma \rangle$, let $Q=Q_{S, A}$ be the space of bounded real-valued functions over $S\times A$. We define the Bellman Optimality Operator $T_Q^\ast:Q\rightarrow Q$ as:
 
 $$
 (T_Q^* f)(s, a)=\mathbb{E} \bigg[ r(s, a) + \gamma  \max_{a'\in A}f(s',a') \bigg| s, a \bigg], \;\forall f \in Q
@@ -72,7 +72,7 @@ $$
 
 ### What is this operator?
 
-This is the q-version of the previous Bellman Optimality Operator $T_V^*$. Similarly, this operator is a $\gamma$-contraction with the unique fixed point being $f=q^*$, the optimal q-value function of the MDP. Therefore, if we apply this operator iteratively to some (value) function $q$, it will converge to the optimal value function $q^*$. We may attempt to approximate this operator too.
+This is the q-version of the previous Bellman Optimality Operator $T_V^\ast$. Similarly, this operator is a $\gamma$-contraction with the unique fixed point being $f=q^\ast$, the optimal q-value function of the MDP. Therefore, if we apply this operator iteratively to some (value) function $q$, it will converge to the optimal value function $q^\ast$. We may attempt to approximate this operator too.
 
 ### Definition: Bellman Expectation Operator $T^\pi_Q$
 
@@ -90,23 +90,23 @@ $$
 
 ### What is this operator?
 
-This is the q-version of the previous Bellman Expectation Operator $T_V^\pi$. It is also a $\gamma$-contraction, with the unique fixed point being $f=q^\pi$. Therefore, we can evaluate the policy $\pi$ by repeatedly applying this operator to the initial value function $q$. We then know the performance of the policy $\pi$. Since this is a q-value function, we can also use it to greedify our policy $\pi$ by $\pi \leftarrow \argmax_{a\in A} q^\pi(s, a)$.
+This is the q-version of the previous Bellman Expectation Operator $T_V^\pi$. It is also a $\gamma$-contraction, with the unique fixed point being $f=q^\pi$. Therefore, we can evaluate the policy $\pi$ by repeatedly applying this operator to the initial value function $q$. We then know the performance of the policy $\pi$. Since this is a q-value function, we can also use it to greedify our policy $\pi$ by $\pi \leftarrow \arg\max_{a\in A} q^\pi(s, a)$.
 
 ## Properties of the Bellman Operators
 
-### Properties: Bellman Optimality Operator $T_V^* \;(= T^*)$
+### Properties: Bellman Optimality Operator $T_V^\ast \;(= T^\ast)$
 
-1. $T^*$ has a unique fixed point $v^*$.
-2. $T^*$ is a $\gamma$-contraction with respect to $\|\cdot\|_\infty$:
+1. $T^\ast$ has a unique fixed point $v^\ast$.
+2. $T^\ast$ is a $\gamma$-contraction with respect to $\|\cdot\|_\infty$:
     
     $$
     \|T^*v-T^*u\|_\infty \le \gamma \|v-u\|_\infty, \forall u,v \in V
     $$
     
-3. $T^*$ is monotonic:
+3. $T^\ast$ is monotonic:
 
 $$
-\forall u,v \in V \text{ s.t. } u \le v \text{ component-wise, then } T^*u \le T^*v
+\forall u,v \in V \text{ s.t. } u \le v \text{ component-wise, then } T^\ast u \le T^\ast v
 $$
 
 **The properties are similar for all other operators.**
@@ -124,13 +124,13 @@ An example of divergence induced by some approximation is explored in the lectur
 Consider an MDP. Let $q:S\times A \rightarrow \mathbb{R}$ be an arbitrary function and let $\pi$ be the greedy policy associated with $q$, then:
 
 $$
-\|q^* - q^\pi \|_\infty \le \frac{2\gamma}{1-\gamma} \|q^*-q\|_{\infty}
+\|q^\ast - q^\pi \|_\infty \le \frac{2\gamma}{1-\gamma} \|q^\ast-q\|_{\infty}
 $$
 
-where $q^*$ is the optimal value function associated with this MDP.
+where $q^\ast$ is the optimal value function associated with this MDP.
 
 We can gain insights from this theorem:
 
 1. Small values of $\gamma$ give a better (lower) upper bound for the potential loss of the performance. (Why?)
-2. If $\gamma=0$, then $q^*=q^\pi$. Therefore, the greedy policy associated with any $q$ yields the optimal value function.
-3. If $q=q^*$, it means that the value function, from which you are about to make the greedy policy out of, is the optimal value function. The greedy policy is the optimal policy, hence $q^*=q^\pi$ in this case.
+2. If $\gamma=0$, then $q^\ast=q^\pi$. Therefore, the greedy policy associated with any $q$ yields the optimal value function.
+3. If $q=q^\ast$, it means that the value function, from which you are about to make the greedy policy out of, is the optimal value function. The greedy policy is the optimal policy, hence $q^\ast=q^\pi$ in this case.

--- a/assets/blog/reinforcement-learning-basics/DeepMind X UCL 6 Model-free Control c55a856c97414c309f4e93dff6774282.md
+++ b/assets/blog/reinforcement-learning-basics/DeepMind X UCL 6 Model-free Control c55a856c97414c309f4e93dff6774282.md
@@ -7,7 +7,7 @@ GLIE stands for **Greedy in the Limit with Infinite Exploration**. It is used to
 1. **Greedy in the Limit** means that the policy eventually converges to a greedy policy, i.e.
     
     $$
-    \lim_{t \rightarrow \infty} {\pi_t(a|s)}=I(a=\argmax_{a' \in A}{q_t(s,a')})
+    \lim_{t \rightarrow \infty} {\pi_t(a|s)}=I(a=\arg\max_{a' \in A}{q_t(s,a')})
     $$
     
 2. **Infinite Exploration** means that all state-action pairs are explored infinitely many times, i.e.
@@ -28,13 +28,13 @@ $$
 \begin{aligned} (T_V^*f)(s)&=\max_{a \in A} \biggl[ {r(s, a) + \gamma \mathbb{E} \left[f(s')|s, a\right]} \bigg], \;\forall f \in V \\ (T_V^\pi f)(s)&=\mathbb{E}^\pi \bigg[ r(s, a) + \gamma  f(s') \bigg| s, a \bigg], \;\forall f \in V \\(T_Q^*f)(s,a)&=\mathbb{E} \bigg[r(s, a) + \gamma \max_{a'\in A} f(s',a') \bigg|s, a\bigg], \;\forall f \in Q \\ (T_Q^\pi f)(s, a)&=\mathbb{E}^\pi \bigg[ r(s, a) + \gamma  f(s',a') \bigg| s, a \bigg], \;\forall f \in Q \end{aligned}
 $$
 
-To apply a Bellman operator we need exact knowledge of the transition dynamics of the system. We can avoid this problem using a sampled version of the operator. It turns out that the sampled versions of the above Bellman operators correspond to different model-free algorithms, except for $(T_V^*f)(s)$:
+To apply a Bellman operator we need exact knowledge of the transition dynamics of the system. We can avoid this problem using a sampled version of the operator. It turns out that the sampled versions of the above Bellman operators correspond to different model-free algorithms, except for $(T_V^\ast f)(s)$:
 
 $$
 \begin{aligned} &(T_V^*f)(s)  \leftrightarrow \text{(None)} \\ &(T_V^\pi f)(s)\leftrightarrow \text{(TD)} \\ &\leftrightarrow v_{t+1}(S_t)=v_t(S_t)+\alpha_t\bigg(R_{t+1}+\gamma v_t(S_{t+1})-v_t(S_t)\bigg)\\&(T_Q^*f)(s,a)\leftrightarrow \text{(Q-learning)} \\& \leftrightarrow q_{t+1}(S_t, A_t) = q_t(S_t, A_t) + \alpha_t \bigg(R_{t+1} + \gamma \max_{a' \in A}{q_t(S_{t+1}, a')-q_t(S_t, A_t)\bigg)}\\ &(T_Q^\pi f)(s, a) \leftrightarrow \text{(SARSA)} \\ &\leftrightarrow q_{t+1}(S_t, A_t) = q_t(S_t, A_t) + \alpha_t \bigg(R_{t+1} + \gamma q_t(S_{t+1}, A_{t+1})-q_t(S_t, A_t)\bigg) \end{aligned}
 $$
 
-It is evident that we cannot build a sampled version of the operator $(T_V^*f)(s)$ - Since the $\max_{a \in A}$ and the $\mathbb{E}$ operator do not commute, $(T_V^*f)(s)$ cannot be expressed as an expectation from which we can sample upon.
+It is evident that we cannot build a sampled version of the operator $(T_V^\ast f)(s)$ - Since the $\max_{a \in A}$ and the $\mathbb{E}$ operator do not commute, $(T_V^\ast f)(s)$ cannot be expressed as an expectation from which we can sample upon.
 
 SARSA is relatively simple - it’s simply the $q$-version of TD. However, Q-learning has some interesting properties that deserves attention of its own.
 
@@ -57,15 +57,15 @@ $$
 q_{t+1}(S_t, A_t) = q_t(S_t, A_t) + \alpha_t \bigg(R_{t+1} + \gamma \max_{a' \in A}{q_t(S_{t+1}, a')-q_t(S_t, A_t)\bigg)}
 $$
 
-Here, there is no policy $\pi$ involved - you can use any behavior policy $\mu$ to converge to the optimal value function $q^*$, as long as it is a infinite exploration policy. Once $q^*$ is learned, we can use the (optimal) greedy policy for exploitation:
+Here, there is no policy $\pi$ involved - you can use any behavior policy $\mu$ to converge to the optimal value function $q^\ast$, as long as it is a infinite exploration policy. Once $q^\ast$ is learned, we can use the (optimal) greedy policy for exploitation:
 
 $$
-{\pi^*(a|s)}=I(a=\argmax_{a'\in A}{q^*(s,a')}).
+{\pi^\ast(a|s)}=I(a=\arg\max_{a'\in A}{q^\ast(s,a')}).
 $$
 
 ### Theorem
 
-Q-learning converges to the optimal $q$-value function, $q\rightarrow q^*$, as long as we take each action in each state indefinitely often AND decay the step sizes in such a way that $\sum_t\alpha_t=\infty$ and $\sum_t \alpha_t^2<\infty$.
+Q-learning converges to the optimal $q$-value function, $q\rightarrow q^\ast$, as long as we take each action in each state indefinitely often AND decay the step sizes in such a way that $\sum_t\alpha_t=\infty$ and $\sum_t \alpha_t^2<\infty$.
 
 For example,  
 $\alpha_t= 1/t^\omega, \omega \in (0.5, 1)$.
@@ -81,20 +81,20 @@ $$
 To write things differently:
 
 $$
-\max_{a' \in A}{q_t(S_{t+1}, a')}=q_t\left(S_{t+1}, \argmax_{a' \in A} q_t(S_{t+1}, a')\right)
+\max_{a' \in A}{q_t(S_{t+1}, a')}=q_t\left(S_{t+1}, \arg\max_{a' \in A} q_t(S_{t+1}, a')\right)
 $$
 
-Suppose that the value function is currently inaccurate and has high noise. For simplicity, assume that the optimal q-value function $q^*(S_{t+1},a')$ stays constant regardless of the action $a'$ taken. For some of the $a'$s, the noise will add up to increase $q$. Therefore, the $\argmax_{a' \in A}$ will choose the $a'$ with the highest noise value then update $q(S_t, A_t)$ towards the noise-added value. Similar logic applies to the case where  $q^*(S_{t+1},a')$ is not constant with respect to $a'$. Hence, Q-learning tends to overestimate the optimal $q$-value function.
+Suppose that the value function is currently inaccurate and has high noise. For simplicity, assume that the optimal q-value function $q^\ast(S_{t+1},a')$ stays constant regardless of the action $a'$ taken. For some of the $a'$s, the noise will add up to increase $q$. Therefore, the $\arg\max_{a' \in A}$ will choose the $a'$ with the highest noise value then update $q(S_t, A_t)$ towards the noise-added value. Similar logic applies to the case where  $q^\ast(S_{t+1},a')$ is not constant with respect to $a'$. Hence, Q-learning tends to overestimate the optimal $q$-value function.
 
 ### Double Q-Learning
 
 How can we solve this problem? We can store two action value functions, $q$ and $q'$, and alternate between the two targets below:
 
 $$
-\text{(target for }q \text{):}\;\;R_{t+1} + \gamma q'\left(S_{t+1}, \argmax_{a' \in A} q(S_{t+1},a')\right) \\ \text{(target for }q' \text{):}\;\;R_{t+1} + \gamma q\left(S_{t+1}, \argmax_{a' \in A} q'(S_{t+1},a')\right)
+\text{(target for }q \text{):}\;\;R_{t+1} + \gamma q'\left(S_{t+1}, \arg\max_{a' \in A} q(S_{t+1},a')\right) \\ \text{(target for }q' \text{):}\;\;R_{t+1} + \gamma q\left(S_{t+1}, \arg\max_{a' \in A} q'(S_{t+1},a')\right)
 $$
 
-This eliminates the influence of noise by decoupling the selection ($\argmax$) step and the evaluation step.
+This eliminates the influence of noise by decoupling the selection ($\arg\max$) step and the evaluation step.
 
 ![Q-learning overestimates, whereas double Q-learning does not. 
 (Source: DeepMind X UCL Deep RL lectures)](DeepMind%20X%20UCL%206%20Model-free%20Control%20c55a856c97414c309f4e93dff6774282/Screenshot_2023-08-30_at_3.44.02_PM.png)

--- a/assets/blog/reinforcement-learning-basics/DeepMind X UCL 7 Function Approximation 86cf033e13e0489a902a735dba94a33c.md
+++ b/assets/blog/reinforcement-learning-basics/DeepMind X UCL 7 Function Approximation 86cf033e13e0489a902a735dba94a33c.md
@@ -118,7 +118,7 @@ The above update is called **TD with Linear Approximation**.
 With linear value function approximation and suitably decaying step size $\alpha_t \rightarrow 0$, it is known that MC converges to:
 
 $$
-\mathbf{w}_\text{MC} =\argmin_\mathbf{w} {\mathbb{E}^\pi[(G_t-v_\mathbf{w}(S_t))^2]}=\mathbb{E}^\pi [\mathbf{x}_t \mathbf{x}_t^\top]^{-1} \mathbb{E}^\pi[G_t\mathbf{x}_t]
+\mathbf{w}_\text{MC} =\arg\min_\mathbf{w} {\mathbb{E}^\pi[(G_t-v_\mathbf{w}(S_t))^2]}=\mathbb{E}^\pi [\mathbf{x}_t \mathbf{x}_t^\top]^{-1} \mathbb{E}^\pi[G_t\mathbf{x}_t]
 $$
 
 We can verify this by setting the gradient of ${\mathbb{E}^\pi[(G_t-v_\mathbf{w}(S_t))^2]}$ with respect to $\mathbf{w}$ to zero:


### PR DESCRIPTION
Fix LaTeX rendering for `\argmax` and prevent markdown italic formatting of asterisks in inline math.

The `\argmax` command was not recognized by LaTeX, so it was replaced with `\arg\max`. Additionally, asterisks (`*`) within inline math expressions were sometimes misinterpreted as markdown italic formatting, particularly when multiple such expressions appeared on the same line. This was fixed by replacing `*` with `\ast` in these contexts to ensure proper rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-bcd13ebf-578c-459c-9097-b38bf682fa6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bcd13ebf-578c-459c-9097-b38bf682fa6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

